### PR TITLE
setup use of news api #2

### DIFF
--- a/CST438/api/news.js
+++ b/CST438/api/news.js
@@ -1,0 +1,25 @@
+// Express backend endpoint for mediastack API
+import express from 'express';
+import fetch from 'node-fetch';
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+const API_KEY = 'API_KEY'; // Replace with actual key
+const BASE_URL = 'https://api.mediastack.com/v1/news';
+
+app.get('/api/news', async (req, res) => {
+  try {
+    const params = { ...req.query, access_key: API_KEY };
+    const query = new URLSearchParams(params).toString();
+    const url = `${BASE_URL}?${query}`;
+    const response = await fetch(url);
+    const data = await response.json();
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/CST438/package.json
+++ b/CST438/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "cst438",
   "main": "expo-router/entry",
   "version": "1.0.0",
@@ -24,10 +25,12 @@
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.5",
     "expo-splash-screen": "~0.30.10",
+    "expo-sqlite": "~15.2.14",
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.11",
     "expo-web-browser": "~14.2.0",
+    "express": "^5.1.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.6",
@@ -36,8 +39,7 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5",
-    "expo-sqlite": "~15.2.14"
+    "react-native-webview": "13.13.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
Added a new Express server in api/news.js to proxy requests to the mediastack news API. Updated package.json to set module type and added express.

Testing

1. replace "API_KEY" with actual API key
2. run npm install to get express
3. run the backed server via command node api/news.js
4. test api via custom paramaters

Custom Parameters to try 
- Top US news in English:  http://localhost:3001/api/news?countries=us&languages=en&limit=5
- Business news worldwide: http://localhost:3001/api/news?categories=business&limit=5
- News from specific sources (e.g., CNN, BBC): http://localhost:3001/api/news?sources=cnn,bbc&limit=5
- Most recent publications: http://localhost:3001/api/news?limit=5&sort=published_desc